### PR TITLE
Fix map longitude calculation

### DIFF
--- a/utils/MapManager.py
+++ b/utils/MapManager.py
@@ -1,4 +1,5 @@
 import folium
+import math
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from utils.StatusLogger import StatusLogger
 from services.FuelPriceDB import FuelPriceDB
@@ -13,7 +14,8 @@ class MapManager:
             my_map = folium.Map(location=map_center, zoom_start=13)
             # Dynamisch die Kartenbegrenzungen basierend auf dem Radius festlegen
             lat_offset = rad / 111.0  # 1° Breitengrad entspricht ca. 111 km
-            lon_offset = rad / (111.0 * abs(lat))  # Berücksichtigt Breitenabhängigkeit
+            # 1° Längengrad variiert abhängig vom Breitengrad -> cos(lat)
+            lon_offset = rad / (111.0 * math.cos(math.radians(lat)))
             bounds = [
                 [lat - lat_offset, lon - lon_offset],  # Südwest-Ecke
                 [lat + lat_offset, lon + lon_offset],  # Nordost-Ecke


### PR DESCRIPTION
## Summary
- fix longitude offset computation in MapManager

## Testing
- `python -m py_compile utils/MapManager.py`
- `python -m py_compile main.py mainWindow.py services/*.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6855964cf06c832982df926ba340443e