### PR TITLE
Add Windows build script

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,12 @@
+@echo off
+:: Build Benzinpreis-App executable using PyInstaller
+python -m pip install pyinstaller
+
+if exist build rmdir /s /q build
+if exist dist rmdir /s /q dist
+
+pyinstaller --noconfirm --windowed --onefile ^
+  --icon resources\icons\station.ico ^
+  --add-data "resources;resources" main.py
+
+pause


### PR DESCRIPTION
## Summary
- add a `build.bat` script that packages the PyQt6 app as an executable

## Testing
- `python -m py_compile main.py mainWindow.py`

------
https://chatgpt.com/codex/tasks/task_e_6857056e3708832994ffcb2e0b1dc79b