### PR TITLE
Add resource helper for PyInstaller

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,12 @@
+@echo off
+:: Build Benzinpreis-App executable using PyInstaller
+python -m pip install pyinstaller
+
+if exist build rmdir /s /q build
+if exist dist rmdir /s /q dist
+
+pyinstaller --noconfirm --windowed --onefile ^
+  --icon resources\icons\station.ico ^
+  --add-data "resources;resources" main.py
+
+pause

--- a/main.py
+++ b/main.py
@@ -1,14 +1,15 @@
 import sys
-from PyQt6.QtWidgets import QApplication, QWidget  
-from mainWindow import MainWindow
+from PyQt6.QtWidgets import QApplication, QWidget
 from PyQt6.QtGui import QIcon
+from mainWindow import MainWindow
+from utils.path_utils import resource_path
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
     app.setApplicationName("Benzinpreis App")
     app.setApplicationVersion("1.0.0")
     app.setOrganizationName("Fachhochschule Südwestfalen") 
-    app.setWindowIcon(QIcon("resources/icons/station.ico"))
+    app.setWindowIcon(QIcon(resource_path("resources/icons/station.ico")))
     mainWindow = MainWindow()
     mainWindow.show()
     sys.exit(app.exec())

--- a/mainWindow.py
+++ b/mainWindow.py
@@ -2,6 +2,7 @@ import os
 import uuid
 from PyQt6.uic import loadUi
 from dotenv import load_dotenv
+from utils.path_utils import resource_path
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from PyQt6.QtWidgets import (QMainWindow, QTableWidget, QTableWidgetItem, QHeaderView, 
     QGridLayout, QTableWidget, QToolButton, QSlider, QLineEdit, QLabel, QWidget, QVBoxLayout, QSizePolicy,
@@ -63,10 +64,10 @@ class MainWindow(QMainWindow):
         self.lblAddress: QLabel
         self.lblDieselPrice: QLabel
         self.lcdE10: QLabel
-        loadUi("resources/ui/mainWindow.ui", self)
-        load_dotenv("resources/env/tankerkoenig.env")
+        loadUi(resource_path("resources/ui/mainWindow.ui"), self)
+        load_dotenv(resource_path("resources/env/tankerkoenig.env"))
         self.setWindowTitle("Benzinpreis App")
-        self.setWindowIcon(QIcon("resources/icons/station.ico"))
+        self.setWindowIcon(QIcon(resource_path("resources/icons/station.ico")))
         self.setGeometry(200, 200, 1200, 800)
         self.api_key = os.getenv("API_KEY")
         self.radius = 5
@@ -85,7 +86,7 @@ class MainWindow(QMainWindow):
         StatusLogger.set_status_bar(self.statusBar)
         MainWindow._status_bar = self.statusBar
 
-        self.loading_player = UIHelper.create_image_player("resources/icons/loading.gif", self.centralStackedWidget.widget(1))
+        self.loading_player = UIHelper.create_image_player(resource_path("resources/icons/loading.gif"), self.centralStackedWidget.widget(1))
         self.gridLayoutHistory.addWidget(self.loading_player, 0, 0, -1, -1, Qt.AlignmentFlag.AlignCenter)
 
     def setup_ui(self):
@@ -94,8 +95,8 @@ class MainWindow(QMainWindow):
         self.btnDiesel.setChecked(True)
         self.stackedWidget.setCurrentIndex(0)
         self.centralStackedWidget.setCurrentIndex(0)
-        UIHelper.apply_stylesheet(self, "resources/stylesheets/lightStyle.qss")
-        UIHelper.load_fonts('resources/fonts/SitkaVF.ttf')
+        UIHelper.apply_stylesheet(self, resource_path("resources/stylesheets/lightStyle.qss"))
+        UIHelper.load_fonts(resource_path('resources/fonts/SitkaVF.ttf'))
         self.go_to_my_location()
         self.btnBackToHome.setVisible(False)
         

--- a/services/FuelPriceDB.py
+++ b/services/FuelPriceDB.py
@@ -1,6 +1,7 @@
 import sqlite3
 import os
 import csv
+from utils.path_utils import resource_path
 import pandas as pd
 from datetime import datetime
 from typing import Dict, List, Tuple
@@ -8,7 +9,7 @@ from utils.StatusLogger import StatusLogger
 
 class FuelPriceDB:
     def __init__(self):
-        self.db_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'resources/Database/fuel_prices.db')
+        self.db_path = resource_path('resources/Database/fuel_prices.db')
         self.conn = sqlite3.connect(self.db_path)
         self.cursor = self.conn.cursor()
 

--- a/utils/MapManager.py
+++ b/utils/MapManager.py
@@ -2,6 +2,7 @@ import folium
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from utils.StatusLogger import StatusLogger
 from services.FuelPriceDB import FuelPriceDB
+from utils.path_utils import resource_path
 class MapManager:
     def __init__(self, map_view: QWebEngineView):
         self.map_view: QWebEngineView = map_view
@@ -38,7 +39,7 @@ class MapManager:
                     popup=folium.Popup(popup_html, max_width=250),  # Popup mit HTML-Inhalt
                     tooltip=tooltip_html,  # Tooltip mit HTML-Inhalt
                 ).add_to(my_map)
-            my_map.save("resources/map/map.html")
+            my_map.save(resource_path("resources/map/map.html"))
             self.map_view.setHtml(my_map.get_root().render())
             StatusLogger.success(f"Map loaded with {len(stations)} stations")
         except Exception as e:

--- a/utils/UIHelper.py
+++ b/utils/UIHelper.py
@@ -3,6 +3,7 @@ from PyQt6.QtGui import QIcon, QFont, QMovie, QFontDatabase
 from PyQt6.QtCore import Qt, QByteArray
 
 from services.FuelPriceDB import FuelPriceDB
+from utils.path_utils import resource_path
 
 class UIHelper:
     @staticmethod
@@ -25,7 +26,7 @@ class UIHelper:
             table.setItem(row_idx, 0, QTableWidgetItem(f"{station.get('brand', 'Unbekannt')} Tankstelle"))
             table.setItem(row_idx, 1, QTableWidgetItem(f"{station.get('price', 'N/A')} €"))
             icon_item = QTableWidgetItem()
-            icon_item.setIcon(QIcon("resources/icons/arrow.png"))
+            icon_item.setIcon(QIcon(resource_path("resources/icons/arrow.png")))
             table.setItem(row_idx, 2, icon_item)
             table.setRowHeight(row_idx, 50)
             row_idx += 1
@@ -33,7 +34,7 @@ class UIHelper:
     @staticmethod
     def load_fonts(path):
         QFontDatabase.addApplicationFont(path)
-        app_font = QFont('resources/fonts/SitkaVF.ttf')
+        app_font = QFont(resource_path('resources/fonts/SitkaVF.ttf'))
         QApplication.setFont(app_font)
 
     @staticmethod

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+def resource_path(relative_path: str) -> str:
+    """Return absolute path to resource, compatible with PyInstaller."""
+    base = getattr(sys, '_MEIPASS', BASE_DIR)
+    return os.path.join(base, relative_path)


### PR DESCRIPTION
## Summary
- add a helper to resolve resource paths when frozen
- use helper in main window and other modules

## Testing
- `python -m py_compile main.py mainWindow.py utils/UIHelper.py services/FuelPriceDB.py utils/MapManager.py utils/path_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6857056e3708832994ffcb2e0b1dc79b